### PR TITLE
Fix: Export degreesToNmea in nmea.lua for Kalman filter compatibility

### DIFF
--- a/root/usr/share/gpoint/gpoint
+++ b/root/usr/share/gpoint/gpoint
@@ -13,6 +13,7 @@ local socket = require("socket")
 local nixio = require("nixio.fs")
 local ubus = require("ubus")
 local uci = require("luci.model.uci")
+local nmea = require("nmea")
 
 function portActive(port)
     local fport = nixio.glob("/dev/tty[A-Z][A-Z]*")
@@ -257,7 +258,7 @@ while true do
             end
             kalman = kalmanFilter.update_velocity2d(kalman, GnssData.gp.latitude, GnssData.gp.longitude, os.time() - secondsSinceLastUpdate)
             GnssData.gp.latitude, GnssData.gp.longitude = kalmanFilter.get_lat_lon(kalman)
-            GnssData.gga.latitude, GnssData.gga.longitude = locator.degreesToNmea(GnssData.gp.latitude), ('0' .. locator.degreesToNmea(GnssData.gp.longitude))
+            GnssData.gga.latitude, GnssData.gga.longitude = nmea.degreesToNmea(GnssData.gp.latitude), ('0' .. nmea.degreesToNmea(GnssData.gp.longitude))
             GnssData.gns.latitude, GnssData.gns.longitude = GnssData.gga.latitude, GnssData.gga.longitude
             server_kalman_status = "run"
         else

--- a/root/usr/share/gpoint/lib/nmea.lua
+++ b/root/usr/share/gpoint/lib/nmea.lua
@@ -411,4 +411,14 @@ function nmea.startGNSS(port, command)
     return error, resp
 end
 
+-- Converts decimal degrees to NMEA format (ddmm.mmmmm)
+local function degreesToNmea(coord)
+    local degrees = math.floor(coord)
+    coord = math.abs(coord) - degrees
+    local sign = coord < 0 and "-" or ""
+    return sign .. string.format("%02i%02.5f", degrees, coord * 60.00)
+end
+
+nmea.degreesToNmea = degreesToNmea
+
 return nmea


### PR DESCRIPTION
### Summary
This pull request fixes a runtime error that occurred when enabling the Kalman filter feature. The error was caused by the main script attempting to call degreesToNmea from the nmea module, but this function was not previously exported there.

### Details

- Added the degreesToNmea function to `root/usr/share/gpoint/lib/nmea.lua` and exported it as nmea.degreesToNmea.
- Updated the Kalman filter output in the main script (`root/usr/share/gpoint/gpoint`) to use `nmea.degreesToNmea`.
- This resolves the error: `attempt to call field 'degreesToNmea' (a nil value)` which appeared in the logs when the Kalman filter was enabled.
